### PR TITLE
Add support for recursive inclusion of roles

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -12,16 +12,19 @@ when '2.3.3' then
 
   appraise 'rails507' do
     gem 'rails', '5.0.7'
+    gem 'grape', '1.1.0'
     gem 'rails-controller-testing'
   end
 
   appraise 'rails516' do
     gem 'rails', '5.1.6'
+    gem 'grape', '1.1.0'
     gem 'rails-controller-testing'
   end
 
   appraise 'rails521' do
     gem 'rails', '5.2.1'
+    gem 'grape', '1.1.0'
     gem 'rails-controller-testing'
   end
 

--- a/gemfiles/rails507.gemfile
+++ b/gemfiles/rails507.gemfile
@@ -7,6 +7,6 @@ gem "mocha", "~> 1.0", require: false
 gem "sqlite3"
 gem "rails", "5.0.7"
 gem "rails-controller-testing"
-gem 'grape', "~> 1.1"
+gem 'grape', "1.1.0"
 
 gemspec path: "../"

--- a/gemfiles/rails516.gemfile
+++ b/gemfiles/rails516.gemfile
@@ -7,6 +7,6 @@ gem "mocha", "~> 1.0", require: false
 gem "sqlite3"
 gem "rails", "5.1.6"
 gem "rails-controller-testing"
-gem 'grape', "~> 1.1"
+gem 'grape', "1.1.0"
 
 gemspec path: "../"

--- a/gemfiles/rails521.gemfile
+++ b/gemfiles/rails521.gemfile
@@ -7,6 +7,6 @@ gem "mocha", "~> 1.0", require: false
 gem "sqlite3"
 gem "rails", "5.2.1"
 gem "rails-controller-testing"
-gem 'grape', "~> 1.1"
+gem 'grape', "1.1.0"
 
 gemspec path: "../"

--- a/lib/declarative_authorization/authorization.rb
+++ b/lib/declarative_authorization/authorization.rb
@@ -345,17 +345,16 @@ module Authorization
       [user, roles, privileges]
     end
 
-    def flatten_roles(roles)
+    def flatten_roles(roles, ignore: [])
       # TODO: caching?
       hierarchy = role_hierarchy
       flattened_roles = {}
       roles.each do |role|
         flattened_roles[role] = true
-        if (hierarchy_for_role = hierarchy[role])
-          hierarchy_for_role.each do |r|
-            flattened_roles[r] = true
-          end
-        end
+
+        children = (hierarchy[role] || []) - ignore
+        ignore += flattened_roles.keys
+        flattened_roles.merge!(flatten_roles(children, ignore: ignore)) if children.any?
       end
       flattened_roles
     end

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-require File.join(File.dirname(__FILE__), %w{.. lib declarative_authorization in_model})
+require File.expand_path(File.join(File.dirname(__FILE__), %w{.. lib declarative_authorization in_model}))
 
 ActiveRecord::Base.send :include, Authorization::AuthorizationInModel
 #ActiveRecord::Base.logger = Logger.new(STDOUT)


### PR DESCRIPTION
This PR fixes a bug where multiple levels of role inclusion do not work.

For example, given the roles defined below, a user with role `:test_role` would not include the role `:lowest_role`.
```
      authorization do
        role :test_role do
          includes :lower_role
          has_permission_on :permissions, :to => :test
        end
        role :lower_role do
          has_permission_on :permissions, :to => :lower
          includes :lowest_role
        end
        role :lowest_role do
          has_permission_on :permissions, :to => :lowest
        end
      end
```
