### PR TITLE
Fix issue with flatten_roles performance

### DIFF
--- a/lib/declarative_authorization/authorization.rb
+++ b/lib/declarative_authorization/authorization.rb
@@ -353,8 +353,7 @@ module Authorization
         flattened_roles[role] = true
 
         children = (hierarchy[role] || []) - ignore
-        ignore += flattened_roles.keys
-        flattened_roles.merge!(flatten_roles(children, ignore: ignore)) if children.any?
+        flattened_roles.merge!(flatten_roles(children, ignore: ignore + [role])) if children.any?
       end
       flattened_roles
     end


### PR DESCRIPTION
This PR fixes a performance issue introduced by https://github.com/appfolio/ae_declarative_authorization/pull/12.

The original intent was to avoid circular recursiveness by passing an `:ignore` parameter to `flatten_roles`. The problem is that the `:ignore` list included all roles the user had rather than just the parent role.

This resulted in calls to `flatten_roles` in some cases taking up to 100ms, adding many seconds to requests in large rails apps.

The fix here is to only pass the parent role rather than all roles.