### PR TITLE
Add support for Grape 1.2

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -18,19 +18,19 @@ when '2.3.3' then
 
   appraise 'rails516' do
     gem 'rails', '5.1.6'
-    gem 'grape', '1.1.0'
+    gem 'grape', '1.2.3'
     gem 'rails-controller-testing'
   end
 
   appraise 'rails521' do
     gem 'rails', '5.2.1'
-    gem 'grape', '1.1.0'
+    gem 'grape', '1.2.3'
     gem 'rails-controller-testing'
   end
 
   appraise 'rails522' do
     gem 'rails', '5.2.2'
-    gem 'grape', '1.1.0'
+    gem 'grape', '1.2.3'
     gem 'rails-controller-testing'
   end
 

--- a/gemfiles/rails516.gemfile
+++ b/gemfiles/rails516.gemfile
@@ -6,7 +6,7 @@ gem "appraisal", "~> 2.1"
 gem "mocha", "~> 1.0", require: false
 gem "sqlite3", "~> 1.3.0"
 gem "rails", "5.1.6"
-gem "grape", "1.1.0"
+gem "grape", "1.2.3"
 gem "rails-controller-testing"
 
 gemspec path: "../"

--- a/gemfiles/rails521.gemfile
+++ b/gemfiles/rails521.gemfile
@@ -6,7 +6,7 @@ gem "appraisal", "~> 2.1"
 gem "mocha", "~> 1.0", require: false
 gem "sqlite3", "~> 1.3.0"
 gem "rails", "5.2.1"
-gem "grape", "1.1.0"
+gem "grape", "1.2.3"
 gem "rails-controller-testing"
 
 gemspec path: "../"

--- a/gemfiles/rails522.gemfile
+++ b/gemfiles/rails522.gemfile
@@ -6,7 +6,7 @@ gem "appraisal", "~> 2.1"
 gem "mocha", "~> 1.0", require: false
 gem "sqlite3", "~> 1.3.0"
 gem "rails", "5.2.2"
-gem "grape", "1.1.0"
+gem "grape", "1.2.3"
 gem "rails-controller-testing"
 
 gemspec path: "../"

--- a/lib/declarative_authorization/controller/grape.rb
+++ b/lib/declarative_authorization/controller/grape.rb
@@ -54,7 +54,11 @@ module Authorization
           protected
 
           def api_class
-            options[:for]
+            if options[:for].respond_to?(:base)
+              options[:for].base # Grape >= 1.2.0 controller
+            else
+              options[:for]      # Grape  < 1.2.0 controller
+            end
           end
         end
       end

--- a/lib/declarative_authorization/controller_permission.rb
+++ b/lib/declarative_authorization/controller_permission.rb
@@ -68,7 +68,11 @@ module Authorization
 
     def controller_class(contr)
       if defined?(Grape) && contr.class < Grape::Endpoint
-        contr.options[:for] # Grape controller
+        if contr.options[:for].respond_to?(:base)
+          contr.options[:for].base # Grape >= 1.2.0 controller
+        else
+          contr.options[:for]      # Grape  < 1.2.0 controller
+        end
       else
         contr.class         # Rails controller
       end


### PR DESCRIPTION
Grape 1.2 made internal changes that break declarative authorization. This PR adds support for Grape 1.2.

See https://github.com/ruby-grape/grape/blob/master/UPGRADING.md for more details.