### PR TITLE
Prevent unnecessary files from being included in built gem

### DIFF
--- a/declarative_authorization.gemspec
+++ b/declarative_authorization.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://github.com/appfolio/ae_declarative_authorization'
   s.licenses    = ['MIT']
 
-  s.files         = Dir['**/*']
+  s.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|gemfiles)/}) }
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']


### PR DESCRIPTION
The gemspec currently includes all files, which means test logs and previously built versions of the gem are included.

```
 753152  3 Oct  2018 ae_declarative_authorization-0.9.0.gem
 162304 23 Sep  2018 ae_declarative_authorization-0.9.0.tim1.gem
1149440 18 Dec  2018 ae_declarative_authorization-0.9.1.gem
2297344 20 Dec  2018 ae_declarative_authorization-0.9.2.gem
4655104 10 Apr 20:35 ae_declarative_authorization-0.10.0.gem
9431552 14 Apr 16:59 ae_declarative_authorization-0.10.1.gem
  36864 17 Jul 16:49 ae_declarative_authorization-0.10.2.gem
```