### PR TITLE
Memoize user roles for user

### DIFF
--- a/lib/declarative_authorization/authorization.rb
+++ b/lib/declarative_authorization/authorization.rb
@@ -346,10 +346,8 @@ module Authorization
     end
 
     def flattened_roles(user)
-      @flatten_roles ||= Hash.new do |h, key|
-        h[user] = flatten_roles(roles_for(user))
-      end
-      @flatten_roles[user]
+      @flatten_roles ||= {}
+      @flatten_roles[user] ||= flatten_roles(roles_for(user))
     end
 
     def flatten_roles(roles, ignore: [])

--- a/lib/declarative_authorization/authorization.rb
+++ b/lib/declarative_authorization/authorization.rb
@@ -275,7 +275,7 @@ module Authorization
 
     # Returns the role symbols and inherritted role symbols for the given user
     def roles_with_hierarchy_for(user)
-      flatten_roles(roles_for(user))
+      flattened_roles(user)
     end
 
     def self.development_reload?
@@ -340,9 +340,16 @@ module Authorization
       raise AuthorizationUsageError, "No user object given for user id (#{user.try(:id)}) or " +
         "set through Authorization.current_user" unless user
 
-      roles = options[:user_roles] || flatten_roles(roles_for(user))
+      roles = options[:user_roles] || flattened_roles(user)
       privileges = flatten_privileges privileges, options[:context]
       [user, roles, privileges]
+    end
+
+    def flattened_roles(user)
+      @flatten_roles ||= Hash.new do |h, key|
+        h[user] = flatten_roles(roles_for(user))
+      end
+      @flatten_roles[user]
     end
 
     def flatten_roles(roles, ignore: [])


### PR DESCRIPTION
- when profiling memory, we found out this gem allocated lots of objects, which takes up lots of memory too
- for each user, we really do not need to calculate user role multiple times. Memorize this will be much faster than making db queries, even ActiveRecord Query knows to cache the query