### PR TITLE
allow grape to return 405 when route method for route is not defined

### DIFF
--- a/lib/declarative_authorization/controller/grape.rb
+++ b/lib/declarative_authorization/controller/grape.rb
@@ -37,6 +37,12 @@ module Authorization
           end
 
           def filter_access_filter # :nodoc:
+            begin
+              route
+            rescue
+              # Acceessing route raises an exception when the response is a 405 MethodNotAllowed
+              return
+            end
             unless allowed?("#{request.request_method} #{route.origin}")
               if respond_to?(:permission_denied, true)
                 # permission_denied needs to render or redirect

--- a/test/grape_api_test.rb
+++ b/test/grape_api_test.rb
@@ -26,6 +26,12 @@ if defined?(Grape)
   class BasicAPITest < ApiTestCase
     tests SpecificMocks
 
+    def test_method_not_allowed
+      reader = Authorization::Reader::DSLReader.new
+      request!(MockUser.new(:test_role), "/specific_mocks/test_action", reader, method: :delete)
+      assert_equal 405, last_response.status
+    end
+
     def test_filter_access_to_receiving_an_explicit_array
       reader = Authorization::Reader::DSLReader.new
 


### PR DESCRIPTION
allow grape to return 405 when route method for route is not defined

Similar to https://gitlab.com/gitlab-org/gitlab-ce/commit/892ff3a3ae640272f8712fb190242f2b1fe010a0, the value of
env[Grape::Env::GRAPE_ROUTING_ARGS] is nil when the http method requested is not allowed resulting
in an execption that masks the 405