### PR TITLE
Ensure the all_public_actions method works for Grape APIs

### DIFF
--- a/lib/declarative_authorization/test/helpers.rb
+++ b/lib/declarative_authorization/test/helpers.rb
@@ -155,8 +155,14 @@ module DeclarativeAuthorization
         alias :access_tests_not_required :this_is_an_abstract_controller_so_it_needs_no_access_tests
 
         def all_public_actions
-          actions = controller_class.public_instance_methods(false)
-          actions += controller_class.superclass.public_instance_methods(false)
+          actions = []
+          if defined?(Grape) && [Grape::API, Grape::API::Instance].any? { |base| controller_class < base }
+            actions += controller_class.routes.map { |api| "#{api.request_method} #{api.origin}" }
+          else
+            actions += controller_class.public_instance_methods(false)
+            actions += controller_class.superclass.public_instance_methods(false)
+          end
+
           actions.reject! do |method|
             method =~ /^_/ ||
               method =~ /^rescue_action/ ||

--- a/lib/declarative_authorization/version.rb
+++ b/lib/declarative_authorization/version.rb
@@ -1,3 +1,3 @@
 module DeclarativeAuthorization
-  VERSION = '0.12.0'.freeze
+  VERSION = '0.12.1.tim1'.freeze
 end


### PR DESCRIPTION
The `DeclarativeAuthorization::Test::Helpers` module includes a method called `all_public_actions` that is responsible for determining the set of publically available methods on a controller. This is used to verify that every public method has associated access tests.

This method assumes that the controller is a Rails controller, so does not work correctly with Grape APIs. This means that it is possible for APIs to be missing authorization rules.

This PR fixes the issue by adjusting the `all_public_actions` method to behave differently when run against Grape APIs.