### PR TITLE
Add callback to Engine's permit method

### DIFF
--- a/lib/declarative_authorization/authorization.rb
+++ b/lib/declarative_authorization/authorization.rb
@@ -175,6 +175,9 @@ module Authorization
 
       user, roles, privileges = user_roles_privleges_from_options(privilege, options)
 
+      callback = Rails.application.config.try(:ae_declarative_authorization_permit_callback)
+      callback.call(controller: options[:controller], privilege: privilege) if callback && options.include?(:controller)
+
       return true if roles.is_a?(Hash) && !(roles.keys & omnipotent_roles).empty?
 
       # find a authorization rule that matches for at least one of the roles and

--- a/lib/declarative_authorization/controller_permission.rb
+++ b/lib/declarative_authorization/controller_permission.rb
@@ -29,7 +29,8 @@ module Authorization
                                          :user => contr.send(:current_user),
                                          :object => object,
                                          :skip_attribute_test => !@attribute_check,
-                                         :context => @context || controller_class(contr).decl_auth_context)
+                                         :context => @context || controller_class(contr).decl_auth_context,
+                                         :controller => contr)
     end
 
     def remove_actions(actions)

--- a/lib/declarative_authorization/version.rb
+++ b/lib/declarative_authorization/version.rb
@@ -1,3 +1,3 @@
 module DeclarativeAuthorization
-  VERSION = '0.12.1'.freeze
+  VERSION = '0.13.0'.freeze
 end

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -1366,6 +1366,18 @@ class NamedScopeModelTest < Test::Unit::TestCase
 end
 
 class ModelTest < Test::Unit::TestCase
+  def test_ensure_permit_callback_is_not_called
+    Rails.application.config.ae_declarative_authorization_permit_callback = "shouldn't matter"
+    reader = Authorization::Reader::DSLReader.new
+    instance = Authorization::Engine.instance(reader)
+    test_model = TestModel.create!
+    test_attr = test_model.create_test_attr_has_one
+    user = MockUser.new(:test_role, :test_attr => test_attr)
+    instance.permit?(:update, :user => user, :object => test_model.test_attr_has_one)
+  ensure
+    Rails.application.config.ae_declarative_authorization_permit_callback = nil
+  end
+
   def test_permit_with_has_one_raises_no_name_error
     reader = Authorization::Reader::DSLReader.new
     reader.parse %{

--- a/test/rails_controller_test.rb
+++ b/test/rails_controller_test.rb
@@ -25,6 +25,24 @@ end
 class BasicControllerTest < ActionController::TestCase
   tests SpecificMocksController
 
+  def test_permit_callback
+    callback_called = false
+
+    Rails.application.config.ae_declarative_authorization_permit_callback = Proc.new do |controller:, privilege:|
+      callback_called = true
+      assert_equal 'SpecificMocksController', controller.class.name
+      assert_equal 'test_action', controller.action_name
+      assert_equal :test, privilege
+    end
+
+    reader = Authorization::Reader::DSLReader.new
+    request!(MockUser.new(:test_role), "test_action", reader)
+
+    assert callback_called
+  ensure
+    Rails.application.config.ae_declarative_authorization_permit_callback = nil
+  end
+
   def test_filter_access_to_receiving_an_explicit_array
     reader = Authorization::Reader::DSLReader.new
 


### PR DESCRIPTION
This callback is only made when the Rails application setting
`ae_declarative_authorization_permit_callback` is provided and the call
originates from a controller's permission check.

The purpose of this change is to allow us to log the permission checks being
made as part of a request.