### PR TITLE
Export rubocop config

### DIFF
--- a/declarative_authorization.gemspec
+++ b/declarative_authorization.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = spec.description
   spec.homepage      = 'https://github.com/appfolio/ae_declarative_authorization'
   spec.license       = 'MIT'
-  spec.files         = Dir['**/*'].select { |f| f[%r{^(lib/|LICENSE.txt|.*gemspec)}] }
+  spec.files         = Dir['lib/**/*'] + %w[LICENSE.txt README.md declarative_authorization.gemspec rubocop-decl-auth.yml]
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = Gem::Requirement.new('< 3.4')


### PR DESCRIPTION
The gemspec files config is updated to be more explicit and now includes the readme and rubocop config file, which is necessary for consuming applications to import the custom cop.

the format of the spec files follows that of built-in rails gems like [strong_parameters](https://github.com/rails/strong_parameters/blob/master/strong_parameters.gemspec#L15)