### PR TITLE
Add support for testing granular permissions

### DIFF
--- a/lib/declarative_authorization/test/helpers.rb
+++ b/lib/declarative_authorization/test/helpers.rb
@@ -81,8 +81,8 @@ module DeclarativeAuthorization
         def privilege(privilege, &block)
           privileges = [privilege].flatten.uniq
 
-          unless privileges.all? { |privilege| [:hidden, :read, :write, :write_without_delete].include?(privilege) }
-            raise "Privilege (:when) must be :hidden, :read, :write_without_delete, or :write. Found #{privilege.inspect}."
+          unless privileges.all? { |privilege| [:granted, :hidden, :read, :write, :write_without_delete].include?(privilege) }
+            raise "Privilege (:when) must be :granted, :hidden, :read, :write_without_delete, or :write. Found #{privilege.inspect}."
           end
 
           Blockenspiel.invoke(block, PrivilegeTestGenerator.new(@test_class, @role, privileges))


### PR DESCRIPTION
This PR updates the test helper to add support for the `:granted` privilege. This privilege is needed to support granular permissions that are either granted or not, rather than having multiple privilege levels. Granular permissions are either `:hidden` or `:granted`.