### PR TITLE
Upload test coverage reports to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,3 +15,6 @@ workflows:
                 - '3.4.1'
                 - '3.3.6'
                 - '3.2.5'
+          post-steps:
+            - store_artifacts:
+                path: .coverage

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /pkg/
 /tmp/
 /test/profiles/
+.coverage
 
 # Only generate Appraisal gemfiles on CI
 /gemfiles/

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,11 +1,19 @@
 require 'rubygems'
 require 'bundler'
+require 'simplecov'
 begin
   Bundler.setup(:default, :development)
 rescue Bundler::BundlerError => e
   $stderr.puts e.message
   $stderr.puts "Run `bundle install` to install missing gems"
   exit e.status_code
+end
+
+SimpleCov.start do
+  add_filter "/test/"
+  enable_coverage :branch
+  minimum_coverage line: 91, branch: 76
+  coverage_dir '.coverage'
 end
 
 require 'debug'


### PR DESCRIPTION
This PR:

1. Configures `Simplecov` for test coverage and sets the minimum coverage values to the current test coverage so that we don't drop below existing coverage.
2. Uploads test coverage reports as part of the post-testing steps.