### PR TITLE
[APT-2440] Authorization Denied Events

### DIFF
--- a/lib/declarative_authorization/authorization.rb
+++ b/lib/declarative_authorization/authorization.rb
@@ -21,6 +21,24 @@ module Authorization
   # The exception is raised to ensure that the entire rule is invalidated.
   class NilAttributeValueError < AuthorizationError; end
 
+  class Config
+    # A function that takes one argument:
+    # - event details (hash)
+    attr_accessor :authorization_denied_callback
+
+    def initialize
+      @authorization_denied_callback = nil
+    end
+  end
+
+  def self.config
+    @config ||= Config.new
+  end
+
+  def self.configure
+    yield config
+  end
+
   AUTH_DSL_FILES = [Pathname.new(Rails.root || '').join("config", "authorization_rules.rb").to_s] unless defined? AUTH_DSL_FILES
 
   # Controller-independent method for retrieving the current user.

--- a/test/rails_controller_test.rb
+++ b/test/rails_controller_test.rb
@@ -180,6 +180,31 @@ class BasicControllerTest < ActionController::TestCase
     @controller.authorization_engine = Authorization::Engine.new(reader)
     assert @controller.permitted_to?(:test)
   end
+
+  def test_authorization_denied_callback_called_on_denial
+    called_args = nil
+    Authorization.config.authorization_denied_callback = proc do |details|
+      called_args = details
+    end
+    reader = Authorization::Reader::DSLReader.new
+    reader.parse %{
+      authorization do
+        role :test_role do
+          has_permission_on :permissions, :to => :test
+        end
+      end
+    }
+    # User does not have permission for test_action_2
+    request!(MockUser.new(:test_role), "test_action_2", reader)
+    assert !@controller.authorized?
+    assert called_args, "authorization_denied_callback should have been called"
+    assert_equal "permissions_2", called_args[:context]
+    assert_equal "test_action_2", called_args[:action]
+    assert_equal "/specific_mocks/test_action_2", called_args[:path]
+    assert_equal false, called_args[:attribute_check_denial]
+  ensure
+    Authorization.config.authorization_denied_callback = nil
+  end
 end
 
 


### PR DESCRIPTION
This PR adds an optional configuration for an authorization denied callback when authorization is denied.

Example callback args:
`{:action=>"edit", :path=>"/user_roles/1/edit", :context=>"user_roles", :attribute_check_denial=>false}`