### PR TITLE
[APT-2828] - Return 405 when Grape signals method not allowed

### DIFF
--- a/lib/declarative_authorization/controller/grape.rb
+++ b/lib/declarative_authorization/controller/grape.rb
@@ -39,11 +39,13 @@ module Authorization
           end
 
           def filter_access_filter # :nodoc:
-            begin
-              route
-            rescue
-              # Acceessing route raises an exception when the response is a 405 MethodNotAllowed
-              return
+            raw = env[::Grape::Env::GRAPE_ALLOWED_METHODS]
+            if raw
+              allowed_methods = raw.is_a?(Array) ? raw : raw.split(/,\s*/)
+              if !allowed_methods.include?(request.request_method)
+                header['Allow'] = allowed_methods.join(', ')
+                raise ::Grape::Exceptions::MethodNotAllowed.new(header)
+              end
             end
 
             action = "#{request.request_method} #{route.origin}"

--- a/test/grape_api_test.rb
+++ b/test/grape_api_test.rb
@@ -378,6 +378,54 @@ if defined?(Grape)
   end
 
   ##################
+  class PatchOnlyMocks < MocksAPI
+    filter_access_to :all
+
+    resources :patch_only_mocks do
+      patch do
+        @authorized = true
+        'nothing'
+      end
+    end
+  end
+
+  class WrongHttpMethodAPITest < ApiTestCase
+    tests PatchOnlyMocks
+
+    def test_wrong_http_method_returns_405_not_403
+      reader = Authorization::Reader::DSLReader.new
+      request!(MockUser.new(:test_role), '/patch_only_mocks', reader, method: :get)
+      assert_equal 405, last_response.status
+    end
+
+    def test_correct_method_without_auth_rule_returns_403
+      reader = Authorization::Reader::DSLReader.new
+      request!(MockUser.new(:test_role), '/patch_only_mocks', reader, method: :patch)
+      assert_equal 403, last_response.status
+    end
+
+    def test_correct_method_with_auth_rule_is_allowed
+      reader = Authorization::Reader::DSLReader.new
+      reader.parse %{
+        authorization do
+          role :test_role do
+            has_permission_on :patch_only_mocks, :to => 'PATCH /patch_only_mocks'
+          end
+        end
+      }
+      request!(MockUser.new(:test_role), '/patch_only_mocks', reader, method: :patch)
+      assert last_endpoint.authorized?
+    end
+
+    def test_wrong_http_method_includes_allow_header
+      reader = Authorization::Reader::DSLReader.new
+      request!(MockUser.new(:test_role), '/patch_only_mocks', reader, method: :get)
+      assert_equal 405, last_response.status
+      assert_includes last_response.headers['Allow'], 'PATCH'
+    end
+  end
+
+  ##################
   class AccessOverwrites < MocksAPI
     filter_access_to 'GET /access_overwrites/test_action', 'GET /access_overwrites/test_action_2',
       :require => :test, :context => :permissions_2


### PR DESCRIPTION
## Summary

- When a request targets a path that exists but with the wrong HTTP method (e.g. `GET` on a `PATCH`-only endpoint), Grape sets `GRAPE_ALLOWED_METHODS` in the env before invoking the endpoint
- The authorization `before`-filter was running before Grape could return 405, causing the request to fail with **403 Forbidden** instead of **405 Method Not Allowed**
- Fix checks `GRAPE_ALLOWED_METHODS` at the start of `filter_access_filter` and returns 405 when the request method is absent from the allowed list

## Root cause

In `Grape::Endpoint#run`, `before` filters run on line 255 before the `GRAPE_ALLOWED_METHODS` check on line 257. The existing rescue block in `filter_access_filter` was intended to handle this, but it only catches cases where `route` access raises an exception. In practice, the Grape router's greedy match populates `GRAPE_ROUTING_ARGS` before calling the endpoint, so `route` is accessible and no exception is raised — authorization proceeds with the wrong method and returns 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)