### PR TITLE
ci: add id-token permission for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
       - master
+    paths:
+      - 'lib/**'
+      - 'declarative_authorization.gemspec'
+      - 'LICENSE.txt'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- Adds `id-token: write` permission to the release workflow so that the publish job can authenticate with RubyGems.org via OIDC trusted publishing

Without this permission, the publish step within `release.yml` cannot exchange an OIDC token for RubyGems credentials.

## JIRA

[BANK-1994](https://appfolio.atlassian.net/browse/BANK-1994)

## Test plan

- [ ] Merge PR and verify the release workflow still runs successfully
- [ ] When a release PR is merged, verify the gem is published to RubyGems.org

[BANK-1994]: https://appfolio.atlassian.net/browse/BANK-1994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ