### PR TITLE
Standardize CI and test configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ source 'https://rubygems.org' do
   gem 'dry-types', '<= 1.8' # Issue with 1.8.1
   gem 'grape', '>= 1.6', '< 3'
   gem 'minitest', '>= 5.27', '< 6'
-  gem 'minitest-reporters', '>= 1.7', '< 2'
+  gem 'minitest-reporters', '>= 1.8', '< 2'
   gem 'mocha', '>= 3', '< 4'
   gem 'rake', '>= 13.3', '< 14'
   gem 'rubocop', '1.85.0', groups: %i[development test]

--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ task default: :test
 Rake::TestTask.new(:test) do |t|
   t.libs << 'lib' << 'test'
   t.pattern = 'test/**/*_test.rb'
-  t.verbose = true
+  t.verbose = false
   t.warning = false
 end
 

--- a/test/authorization_test.rb
+++ b/test/authorization_test.rb
@@ -329,10 +329,11 @@ class AuthorizationTest < Test::Unit::TestCase
       end
     )
     engine = Authorization::Engine.new(reader)
-    Authorization.stub :current_user, MockUser.new do
-      assert engine.permit?(:test, context: :permissions)
-      assert !engine.permit?(:test, context: :permissions_2)
-    end
+    Authorization.stubs(:current_user).returns(MockUser.new)
+    assert engine.permit?(:test, context: :permissions)
+    assert !engine.permit?(:test, context: :permissions_2)
+  ensure
+    Authorization.unstub(:current_user)
   end
 
   def test_default_role
@@ -344,14 +345,16 @@ class AuthorizationTest < Test::Unit::TestCase
         end
       end
     )
-    Authorization.stub :default_role, :anonymous do
-      engine = Authorization::Engine.new(reader)
-      Authorization.stub :current_user, MockUser.new do
-        assert engine.permit?(:test, context: :permissions)
-      end
-      assert !engine.permit?(:test, context: :permissions,
-                                    user: MockUser.new(:guest))
-    end
+    Authorization.stubs(:default_role).returns(:anonymous)
+    engine = Authorization::Engine.new(reader)
+    Authorization.stubs(:current_user).returns(MockUser.new)
+    assert engine.permit?(:test, context: :permissions)
+    Authorization.unstub(:current_user)
+    assert !engine.permit?(:test, context: :permissions,
+                                  user: MockUser.new(:guest))
+  ensure
+    Authorization.unstub(:default_role)
+    Authorization.unstub(:current_user)
   end
 
   def test_invalid_user_model
@@ -1149,14 +1152,15 @@ class AuthorizationTest < Test::Unit::TestCase
     )
 
     engine = Authorization::Engine.new(reader)
-    Authorization.stub :current_user, MockUser.new(:test_role) do
-      assert engine.permit?(:test, context: :permissions)
-      Thread.new do
-        Authorization.current_user = MockUser.new(:test_role2)
-        assert !engine.permit?(:test, context: :permissions)
-      end
-      assert engine.permit?(:test, context: :permissions)
+    Authorization.stubs(:current_user).returns(MockUser.new(:test_role))
+    assert engine.permit?(:test, context: :permissions)
+    Thread.new do
+      Authorization.current_user = MockUser.new(:test_role2)
+      assert !engine.permit?(:test, context: :permissions)
     end
+    assert engine.permit?(:test, context: :permissions)
+  ensure
+    Authorization.unstub(:current_user)
   end
 
   def test_clone

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -156,15 +156,16 @@ class HelperTest < ActionController::TestCase
     }
     request!(nil, :action, reader)
 
-    Authorization.stub :current_user, MockUser.new do
-      assert !has_role?(:test_role)
+    Authorization.stubs(:current_user).returns(MockUser.new)
+    assert !has_role?(:test_role)
 
-      block_evaled = false
-      has_role?(:test_role) do
-        block_evaled = true
-      end
-      assert !block_evaled
+    block_evaled = false
+    has_role?(:test_role) do
+      block_evaled = true
     end
+    assert !block_evaled
+  ensure
+    Authorization.unstub(:current_user)
   end
 
   def test_has_role_with_hierarchy

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -1318,17 +1318,18 @@ class ModelTest < Test::Unit::TestCase
     }
     Authorization::Engine.instance(reader)
 
-    Authorization.stub :current_user, MockUser.new(:test_role) do
-      assert(object = TestModelSecurityModel.create)
+    Authorization.stubs(:current_user).returns(MockUser.new(:test_role))
+    assert(object = TestModelSecurityModel.create)
 
-      assert_nothing_raised { object.update(:attr_2 => 2) }
-      object.reload
-      assert_equal 2, object.attr_2
-      object.destroy
-      assert_raise ActiveRecord::RecordNotFound do
-        TestModelSecurityModel.find(object.id)
-      end
+    assert_nothing_raised { object.update(:attr_2 => 2) }
+    object.reload
+    assert_equal 2, object.attr_2
+    object.destroy
+    assert_raise ActiveRecord::RecordNotFound do
+      TestModelSecurityModel.find(object.id)
     end
+  ensure
+    Authorization.unstub(:current_user)
   end
 
   def test_model_security_write_not_allowed_no_privilege
@@ -1375,24 +1376,25 @@ class ModelTest < Test::Unit::TestCase
     }
     Authorization::Engine.instance(reader)
 
-    Authorization.stub :current_user, MockUser.new(:test_role) do
-      assert(object = TestModelSecurityModel.create)
-      assert_raise Authorization::AttributeAuthorizationError do
-        TestModelSecurityModel.create :attr => 2
-      end
-      object = TestModelSecurityModel.create
-      assert_raise Authorization::AttributeAuthorizationError do
-        object.update(:attr => 2)
-      end
-      object.reload
-
-      assert_nothing_raised do
-        object.update(:attr_2 => 1)
-      end
-      assert_raise Authorization::AttributeAuthorizationError do
-        object.update(:attr => 2)
-      end
+    Authorization.stubs(:current_user).returns(MockUser.new(:test_role))
+    assert(object = TestModelSecurityModel.create)
+    assert_raise Authorization::AttributeAuthorizationError do
+      TestModelSecurityModel.create :attr => 2
     end
+    object = TestModelSecurityModel.create
+    assert_raise Authorization::AttributeAuthorizationError do
+      object.update(:attr => 2)
+    end
+    object.reload
+
+    assert_nothing_raised do
+      object.update(:attr_2 => 1)
+    end
+    assert_raise Authorization::AttributeAuthorizationError do
+      object.update(:attr => 2)
+    end
+  ensure
+    Authorization.unstub(:current_user)
   end
 
   def test_model_security_with_and_without_find_restrictions
@@ -1442,13 +1444,14 @@ class ModelTest < Test::Unit::TestCase
     Authorization::Engine.instance(reader)
 
     test_attr = TestAttr.create
-    Authorization.stub :current_user, MockUser.new(:test_role, :test_attr => test_attr) do
-      object_with_find = TestModelSecurityModelWithFind.create :test_attr => test_attr
-      assert_nothing_raised do
-        object_with_find.class.find(object_with_find.id)
-      end
-      assert_equal 1, test_attr.test_model_security_model_with_finds.length
+    Authorization.stubs(:current_user).returns(MockUser.new(:test_role, :test_attr => test_attr))
+    object_with_find = TestModelSecurityModelWithFind.create :test_attr => test_attr
+    assert_nothing_raised do
+      object_with_find.class.find(object_with_find.id)
     end
+    assert_equal 1, test_attr.test_model_security_model_with_finds.length
+  ensure
+    Authorization.unstub(:current_user)
   end
 
   def test_model_security_delete_unallowed
@@ -1497,9 +1500,10 @@ class ModelTest < Test::Unit::TestCase
     }
     Authorization::Engine.instance(reader)
 
-    Authorization.stub :current_user, MockUser.new(:test_role_unrestricted) do
-      object = TestModelSecurityModel.create :attr => 2
-    end
+    Authorization.stubs(:current_user).returns(MockUser.new(:test_role_unrestricted))
+    object = TestModelSecurityModel.create :attr => 2
+  ensure
+    Authorization.unstub(:current_user)
   end
 
   def test_model_security_no_role_unallowed
@@ -1510,11 +1514,12 @@ class ModelTest < Test::Unit::TestCase
     }
     Authorization::Engine.instance(reader)
 
-    Authorization.stub :current_user, MockUser.new(:test_role_2) do
-      assert_raise Authorization::NotAuthorized do
-        TestModelSecurityModel.create
-      end
+    Authorization.stubs(:current_user).returns(MockUser.new(:test_role_2))
+    assert_raise Authorization::NotAuthorized do
+      TestModelSecurityModel.create
     end
+  ensure
+    Authorization.unstub(:current_user)
   end
 
   def test_model_security_with_assoc
@@ -1533,20 +1538,21 @@ class ModelTest < Test::Unit::TestCase
 
     test_attr = TestAttr.create
     test_attr.role_symbols << :test_role
-    Authorization.stub :current_user, test_attr do
-      assert(object = TestModelSecurityModel.create(:test_attrs => [test_attr]))
-      assert_nothing_raised do
-        object.update(:attr_2 => 2)
-      end
-      without_access_control do
-        object.reload
-      end
-      assert_equal 2, object.attr_2
-      object.destroy
-      assert_raise ActiveRecord::RecordNotFound do
-        TestModelSecurityModel.find(object.id)
-      end
+    Authorization.stubs(:current_user).returns(test_attr)
+    assert(object = TestModelSecurityModel.create(:test_attrs => [test_attr]))
+    assert_nothing_raised do
+      object.update(:attr_2 => 2)
     end
+    without_access_control do
+      object.reload
+    end
+    assert_equal 2, object.attr_2
+    object.destroy
+    assert_raise ActiveRecord::RecordNotFound do
+      TestModelSecurityModel.find(object.id)
+    end
+  ensure
+    Authorization.unstub(:current_user)
   end
 
   def test_model_security_with_update_attrbributes


### PR DESCRIPTION
## Summary
- Update `minitest-reporters` constraint to `>= 1.8, < 2`
- Set `Rake::TestTask` verbose to false

[BANK-2077](https://appfolio.atlassian.net/browse/BANK-2077)

[BANK-2077]: https://appfolio.atlassian.net/browse/BANK-2077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ