### PR TITLE
[BANK-2106] Migrate gem source from RubyGems to JFrog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   gem-tool: appfolio/gem-tool@volatile
+  public-packages: https://raw.githubusercontent.com/appfolio/public-packages/v1/orbs/public-packages.yml
 
 workflows:
   rc:
@@ -15,6 +16,8 @@ workflows:
                 - '4.0.1'
                 - '3.4.8'
                 - '3.3.10'
+          after-checkout-steps:
+            - public-packages/setup
           post-steps:
             - store_artifacts:
                 path: .coverage

--- a/Appraisals
+++ b/Appraisals
@@ -3,7 +3,7 @@
 if Gem::Requirement.new(['>= 3.3', '< 4.1']).satisfied_by?(Gem::Version.new(RUBY_VERSION))
   ['7.2'].product(['1.6', '1.7', '1.8', '2.0', '2.1', '2.2']).each do |rails_version, grape_version|
     appraise "ruby-#{RUBY_VERSION}-rails_#{rails_version}-grape_#{grape_version}_sqlite1" do
-      source 'https://rubygems.org' do
+      source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_declarative_authorization-gem/' do
         gem 'rails', "~> #{rails_version}.0"
         gem 'grape', "~> #{grape_version}.0"
         gem 'sqlite3', '~> 1.7'
@@ -12,7 +12,7 @@ if Gem::Requirement.new(['>= 3.3', '< 4.1']).satisfied_by?(Gem::Version.new(RUBY
   end
   ['8.0', '8.1'].product(['1.6', '1.7', '1.8', '2.0', '2.1', '2.2']).each do |rails_version, grape_version|
     appraise "ruby-#{RUBY_VERSION}-rails_#{rails_version}-grape_#{grape_version}_sqlite2" do
-      source 'https://rubygems.org' do
+      source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_declarative_authorization-gem/' do
         gem 'rails', "~> #{rails_version}.0"
         gem 'grape', "~> #{grape_version}.0"
         gem 'sqlite3', '~> 2.8'

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org' # global source
+source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_declarative_authorization-gem/'
 
-source 'https://rubygems.org' do
+source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_declarative_authorization-gem/' do
   gem 'appraisal', '>= 2.5', '< 3'
   gem 'bundler', '>= 2.6', '< 5'
   gem 'debug', '>= 1.11', '< 2'

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,7 +7,7 @@ metadata:
   tags:
     - oss
   annotations:
-    appfolio.com/package-location: url:https://rubygems.org/gems/ae_declarative_authorization
+    appfolio.com/package-location: url:https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_declarative_authorization-gem/
     appfolio.com/package-type: gem
   name: ae-declarative-authorization
 spec:

--- a/declarative_authorization.gemspec
+++ b/declarative_authorization.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = Gem::Requirement.new('< 4.1')
-  spec.metadata['allowed_push_host'] = 'https://rubygems.org'
+  spec.metadata['allowed_push_host'] = 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_declarative_authorization-gem/'
 
   spec.add_dependency('blockenspiel', ['>= 0.5', '< 1'])
   spec.add_dependency('rails', ['>= 7.2', '< 8.2'])


### PR DESCRIPTION
## Summary
Migrate Ruby gem source from rubygems.org to JFrog as part of org-wide JFrog migration.

## Changes
- Replaced `source 'https://rubygems.org'` with JFrog URL in Gemfile (global and block form)
- Replaced `source 'https://rubygems.org'` with JFrog URL in Appraisals
- Updated `allowed_push_host` in gemspec to JFrog URL
- Updated `package-location` in catalog-info.yaml to JFrog URL
- Added `public-packages` orb and `after-checkout-steps` to CircleCI config
- Created `.github/dependabot.yaml` with JFrog registry configuration

## Why
AppFolio is migrating from RubyGems.org to JFrog for Ruby dependency installation.
Jira Issue: https://appfolio.atlassian.net/browse/BANK-2106

## Test Plan
- CI passes with the new gem source configuration